### PR TITLE
SoapyLMS7: add channel 0 as default to setupStream()

### DIFF
--- a/SoapyLMS7/Streaming.cpp
+++ b/SoapyLMS7/Streaming.cpp
@@ -88,9 +88,13 @@ SoapySDR::Stream *SoapyLMS7::setupStream(
 
     StreamConfig config;
     config.isTx = (direction == SOAPY_SDR_TX);
-    for(size_t i=0; i<channels.size(); ++i)
+
+    //default to channel 0, if none were specified
+    const std::vector<size_t> &channelIDs = channels.empty() ? std::vector<size_t>{0} : channels;
+
+    for(size_t i=0; i<channelIDs.size(); ++i)
     {
-        config.channelID = channels[i];
+        config.channelID = channelIDs[i];
         if (format == SOAPY_SDR_CF32) config.format = StreamConfig::STREAM_COMPLEX_FLOAT32;
         else if (format == SOAPY_SDR_CS16) config.format = StreamConfig::STREAM_12_BIT_IN_16;
         else if (format == SOAPY_SDR_CS12) config.format = StreamConfig::STREAM_12_BIT_COMPRESSED;


### PR DESCRIPTION
setupStream() was setting up no channels when called with the default
argument (empty list), but the SoapySDR device API specifies that an
empty channel list should result in automatic setup.