### PR TITLE
Compilation fix for the fresh ArchLinux system and dualRXTX typo fix

### DIFF
--- a/src/ConnectionNovenaRF7/ConnectionNovenaRF7Entry.cpp
+++ b/src/ConnectionNovenaRF7/ConnectionNovenaRF7Entry.cpp
@@ -17,6 +17,7 @@
 #include <sys/ioctl.h>
 #include <linux/types.h>
 #include <linux/spi/spidev.h>
+#include <linux/i2c.h>
 #include <linux/i2c-dev.h>
 #include <iostream>
 
@@ -42,11 +43,11 @@ bool IsNovenaBoard()
     messages[0].addr = 0xac>>1;
     messages[0].flags = 0;
     messages[0].len = sizeof(set_addr_buf);
-    messages[0].buf = set_addr_buf;
+    messages[0].buf = reinterpret_cast<__u8*> (set_addr_buf);
     messages[1].addr = 0xac>>1;
     messages[1].flags = I2C_M_RD;
     messages[1].len = count;
-    messages[1].buf = data;
+    messages[1].buf = reinterpret_cast<__u8*> (data);
     session.msgs = messages;
     session.nmsgs = 2;
 

--- a/src/examples/dualRXTX.cpp
+++ b/src/examples/dualRXTX.cpp
@@ -54,7 +54,7 @@ int main(int argc, char** argv)
     if ((n = LMS_GetNumChannels(device, LMS_CH_RX)) < 0)
         error();
     cout << "Number of RX channels: " << n << endl;
-    if ((n = LMS_GetNumChannels(device, LMS_CH_RX)) < 0)
+    if ((n = LMS_GetNumChannels(device, LMS_CH_TX)) < 0)
         error();
     cout << "Number of TX channels: " << n << endl;
 


### PR DESCRIPTION
> ~/workspace/LimeSuite/src/examples/ uname -a
Linux phenom 4.8.7-1-ARCH #1 SMP PREEMPT Thu Nov 10 17:22:48 CET 2016 x86_64 GNU/Linux
>~/workspace/LimeSuite/src/examples/ g++ --version
g++ (GCC) 6.2.1 20160830
Copyright (C) 2016 Free Software Foundation, Inc.

Errors encountered while compiling ConnectionNovenaRF7Entry.cpp: two explicit casts and one header include resolve all problems.