### PR TITLE
fix build issue on macOS

### DIFF
--- a/mcu_program/CMakeLists.txt
+++ b/mcu_program/CMakeLists.txt
@@ -3,6 +3,10 @@ cmake_policy(SET CMP0003 NEW)
 #C++11 is a required language feature for this project
 set(CMAKE_CXX_STANDARD 11)
 
+if (APPLE)
+	  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=c++11-narrowing") 
+endif()
+
 if(CMAKE_COMPILER_IS_GNUCXX)
 
     #enable C++11 on older versions of cmake

--- a/mcu_program/common_src/lms7002m_calibrations.c
+++ b/mcu_program/common_src/lms7002m_calibrations.c
@@ -5,6 +5,7 @@
 #include <math.h>
 
 #ifdef __cplusplus
+#include <cstdlib>
 #define VERBOSE 1
 //#define DRAW_GNU_PLOTS
 

--- a/mcu_program/common_src/lms7002m_controls.c
+++ b/mcu_program/common_src/lms7002m_controls.c
@@ -6,6 +6,7 @@
 
 #ifdef __cplusplus
 #include <cmath>
+#include <cstdlib>
 using namespace std;
 #include <chrono>
 #include <thread>


### PR DESCRIPTION
I'm trying to build limesuite on macOS (10.12) but I have some issues.
`/Users/jiangwei/Desktop/LimeSuite/mcu_program/host_src/mcu.c:17:69: error: 
      non-constant-expression cannot be narrowed from type 'int' to 'uint16_t'
      (aka 'unsigned short') in initializer list [-Wc++11-narrowing]
  ...= {id != 0, id, x0002reg & ~interupt6, x0002reg | interupt6, x0002reg & ...
                                            ^~~~~~~~~~~~~~~~~~~~`
and 

`/Users/jiangwei/Desktop/LimeSuite/mcu_program/common_src/lms7002m_calibrations.c:69:22: error: 
      use of undeclared identifier 'abs'; did you mean 'fabs'?
    return (uint8_t)(abs((int)offset) | 0x40);
                     ^~~
                     fabs
/usr/include/math.h:431:15: note: 'fabs' declared here`

I've added fixes to support macOS.