### PR TITLE
Quiet compile warnings by removing unused variables.

### DIFF
--- a/src/ConnectionSTREAM/ConnectionSTREAMing.cpp
+++ b/src/ConnectionSTREAM/ConnectionSTREAMing.cpp
@@ -516,7 +516,6 @@ void ConnectionSTREAM::TransmitPacketsLoop(const ThreadData args)
     auto t1 = chrono::high_resolution_clock::now();
     auto t2 = chrono::high_resolution_clock::now();
 
-    uint64_t timestamp = 0;
     uint8_t bi = 0; //buffer index
     while (terminate->load() != true)
     {
@@ -583,7 +582,7 @@ void ConnectionSTREAM::TransmitPacketsLoop(const ThreadData args)
 #ifndef NDEBUG
             //total number of samples from all channels per second
             float sampleRate = 1000.0*samplesSent / timePeriod;
-            printf("Tx: %.3f MB/s, Fs: %.3f MHz, failures: %i, ts:%li\n", dataRate / 1000000.0, sampleRate / 1000000.0, m_bufferFailures, timestamp);
+            printf("Tx: %.3f MB/s, Fs: %.3f MHz, failures: %i\n", dataRate / 1000000.0, sampleRate / 1000000.0, m_bufferFailures);
 #endif
         }
         bi = (bi + 1) & (buffersCount-1);

--- a/src/ConnectionXillybus/ConnectionXillybusing.cpp
+++ b/src/ConnectionXillybus/ConnectionXillybusing.cpp
@@ -453,7 +453,6 @@ void ConnectionXillybus::TransmitPacketsLoop(const ThreadData args)
     auto t1 = chrono::high_resolution_clock::now();
     auto t2 = chrono::high_resolution_clock::now();
 
-    uint64_t timestamp = 0;
     while (terminate->load() != true)
     {
         int i=0;
@@ -509,7 +508,7 @@ void ConnectionXillybus::TransmitPacketsLoop(const ThreadData args)
 #ifndef NDEBUG
             //total number of samples from all channels per second
             float sampleRate = 1000.0*samplesSent / timePeriod;
-            printf("Tx: %.3f MB/s, Fs: %.3f MHz, failures: %i, ts:%li\n", dataRate / 1000000.0, sampleRate / 1000000.0, m_bufferFailures, timestamp);
+            printf("Tx: %.3f MB/s, Fs: %.3f MHz, failures: %i\n", dataRate / 1000000.0, sampleRate / 1000000.0, m_bufferFailures);
 #endif
         }
     }

--- a/src/Connection_uLimeSDR/Connection_uLimeSDRing.cpp
+++ b/src/Connection_uLimeSDR/Connection_uLimeSDRing.cpp
@@ -331,7 +331,6 @@ void Connection_uLimeSDR::TransmitPacketsLoop(const Connection_uLimeSDR::ThreadD
     auto t1 = chrono::high_resolution_clock::now();
     auto t2 = chrono::high_resolution_clock::now();
 
-    uint64_t timestamp = 0;
     uint8_t bi = 0; //buffer index
     while (terminate->load() != true)
     {
@@ -398,7 +397,7 @@ void Connection_uLimeSDR::TransmitPacketsLoop(const Connection_uLimeSDR::ThreadD
 #ifndef NDEBUG
             //total number of samples from all channels per second
             float sampleRate = 1000.0*samplesSent / timePeriod;
-            printf("Tx: %.3f MB/s, Fs: %.3f MHz, failures: %i, ts:%li\n", dataRate / 1000000.0, sampleRate / 1000000.0, m_bufferFailures, timestamp);
+            printf("Tx: %.3f MB/s, Fs: %.3f MHz, failures: %i\n", dataRate / 1000000.0, sampleRate / 1000000.0, m_bufferFailures);
 #endif
         }
         bi = (bi + 1) & (buffersCount-1);

--- a/src/lms7suiteApp.cpp
+++ b/src/lms7suiteApp.cpp
@@ -39,9 +39,9 @@ bool lms7suiteApp::OnInit()
         6000, NULL, -1, wxDefaultPosition, wxDefaultSize,
         wxSIMPLE_BORDER | wxSTAY_ON_TOP);
     wxYield(); //linux needs this to load splash image
-    wxLongLong t1 = wxGetUTCTimeMillis();
     LMS7SuiteAppFrame* frame = new LMS7SuiteAppFrame(0L);
 #ifndef NDEBUG
+    wxLongLong t1 = wxGetUTCTimeMillis(); 
     std::cout << "Create time " << (wxGetUTCTimeMillis() - t1).ToString() << " ms\n";
 #endif
     splash->Destroy();


### PR DESCRIPTION
Unless the intention was to have a timestamp of 0 it seems okay to remove the 3 and then move the other one into the ifdef.