### PR TITLE
soapy lms7 - make mutex mutable for const methods

### DIFF
--- a/SoapyLMS7/Settings.cpp
+++ b/SoapyLMS7/Settings.cpp
@@ -21,9 +21,6 @@ using namespace lime;
 
 #define dirName ((direction == SOAPY_SDR_RX)?"Rx":"Tx")
 
-//lazy fix for the const call issue -- FIXME
-#define _accessMutex const_cast<std::recursive_mutex &>(_accessMutex)
-
 // arbitrary upper limit for CGEN automatic tune
 #define MAX_CGEN_RATE 640e6
 

--- a/SoapyLMS7/SoapyLMS7.h
+++ b/SoapyLMS7/SoapyLMS7.h
@@ -265,5 +265,5 @@ private:
 
     lime::LMS7002M *getRFIC(const size_t channel) const;
     std::vector<lime::LMS7002M *> _rfics;
-    std::recursive_mutex _accessMutex;
+    mutable std::recursive_mutex _accessMutex;
 };


### PR DESCRIPTION
Minor change to remove a hacky const_cast. Doing this as a PR to check that mutable would compile on the CI builds.