### PR TITLE
As it stands, the auto calibration in SoapyLMS7/Streaming.cpp is acti…

### DIFF
--- a/SoapyLMS7/Streaming.cpp
+++ b/SoapyLMS7/Streaming.cpp
@@ -12,6 +12,7 @@
 #include <thread>
 #include <algorithm> //min/max
 #include "ErrorReporting.h"
+#include <iostream>
 
 using namespace lime;
 
@@ -81,6 +82,17 @@ SoapySDR::ArgInfoList SoapyLMS7::getStreamArgsInfo(const int direction, const si
         argInfos.push_back(info);
     }
 
+    // auto calibration enable
+    {
+        SoapySDR::ArgInfo info;
+        info.value = "0";
+        info.key = "noAutoCal";
+        info.name = "Inhibit Auto Calibration";
+        info.description = "If present, inhibits automatic calibration at activate time.";
+        info.type = SoapySDR::ArgInfo::INT;
+        argInfos.push_back(info);
+    }
+
     return argInfos;
 }
 
@@ -141,10 +153,14 @@ SoapySDR::Stream *SoapyLMS7::setupStream(
     }
 
     //calibrate these channels when activated
+    bool enableAutoCal = ((args.count("noAutoCal") == 0) || (std::stoi(args.at("noAutoCal")) == 0));
     for (const auto &ch : channelIDs)
-    {
-        _channelsToCal.emplace(direction, ch);
-    }
+      {
+	if(enableAutoCal)
+	  _channelsToCal.emplace(direction, ch);
+	else
+	  _channelsToCal.erase(std::pair<int, size_t>(direction, ch));
+      }
 
     return (SoapySDR::Stream *)stream;
 }


### PR DESCRIPTION
…vated when streamActivate is called on any stream for the first time.

This triggers an MCU calibration step (as far as I can tell) that sets
up bad calibration values if the calibration table has not yet been
created.  The result is that readStream on an rx stream will produce
zero values in the I or Q component of many samples.  For some
programs, all the I samples will be zero.  For others, many of the I
or Q samples will be zero.  This is despite all RX gains set to
maximum.  It is extremely unlikely for any real hardware to produce
long strings of zero samples.

To prevent the spurious zero samples, and also to allow other
calibration schemes, this change adds a keyword arg "noAutoCal" to the
setup routine.  If "noAutoCal" is present and its string value is any
non-zero integer, the associated channel and direction pair are
removed from the _channelsToCal set.

This fixes the bad samples issue with new db files, and also eliminates
the auto cal step for client software that does not need it.