### PR TITLE
FFTviewer bug fix: write full capture buffer & out-of-bounds protection

### DIFF
--- a/src/fftviewer_wxgui/fftviewer_frFFTviewer.cpp
+++ b/src/fftviewer_wxgui/fftviewer_frFFTviewer.cpp
@@ -364,11 +364,13 @@ void fftviewer_frFFTviewer::StreamingLoop(fftviewer_frFFTviewer* pthis, const un
 
     vector<complex16_t> captureBuffer[cMaxChCount];
     uint32_t samplesToCapture[cMaxChCount];
+    uint32_t samplesCaptured[cMaxChCount];
     if(pthis->captureSamples.load() == true)
         for(int ch=0; ch<channelsCount; ++ch)
         {
             samplesToCapture[ch] = pthis->spinCaptureCount->GetValue();
             captureBuffer[ch].resize(samplesToCapture[ch]);
+            samplesCaptured[ch] = 0;
         }
 
     if (LMS_GetNumChannels(pthis->lmsControl, false)>2)
@@ -437,11 +439,12 @@ void fftviewer_frFFTviewer::StreamingLoop(fftviewer_frFFTviewer* pthis, const un
             {
                 for(int ch=0; ch<channelsCount; ++ch)
                 {
-                    uint32_t samplesToCopy = samplesPopped[ch] < samplesToCapture[ch] ? samplesPopped[ch] : samplesToCapture[ch];
+                    uint32_t samplesToCopy = min(samplesPopped[ch], samplesToCapture[ch]);
                     if(samplesToCopy <= 0)
                         break;
-                    memcpy(captureBuffer[ch].data(), buffers[ch], samplesPopped[ch]*sizeof(complex16_t));
-                    samplesToCapture[ch] -= samplesPopped[ch];
+                    memcpy((captureBuffer[ch].data() + samplesCaptured[ch]), buffers[ch], samplesToCopy*sizeof(complex16_t));
+                    samplesToCapture[ch] -= samplesToCopy;
+                    samplesCaptured[ch] += samplesToCopy;
                 }
             }
 


### PR DESCRIPTION
This commit fixes two bugs in the capture function of the FFTviewer.

# 1. Write entire capture buffer, not just first segment
Previously, the capture buffer was always [written starting at the address of the first sample](https://github.com/myriadrf/LimeSuite/compare/master...milestone12:master#diff-19366fd8df444a99788a9ae689483f14L440) in every loop iteration. Thus, only the first "segment" of the buffer would contain samples whereas the rest of it would be just '0':
![output file example](https://user-images.githubusercontent.com/31235733/31932315-49821752-b8a6-11e7-89e7-15d2a66ae4d2.png)
An [array of counter variables has been introduced](https://github.com/myriadrf/LimeSuite/compare/master...milestone12:master#diff-19366fd8df444a99788a9ae689483f14R367) in order to keep track of the number of written samples and to [set the initial address for the memcpy operation](https://github.com/myriadrf/LimeSuite/compare/master...milestone12:master#diff-19366fd8df444a99788a9ae689483f14R445) correctly.

# 2. Protection from segmentation fault due to out-of-bounds write
In the case of `samplesToCapture[ch] < samplesPopped[ch]` the memcpy operation would try to write a number of `samplesPopped[ch]` samples and the write pointer would thus run out-of-bounds.
Using the `samplesToCopy` variable now prevents an out-of-bounds case.