### PR TITLE
Soapylms mimo align fix

### DIFF
--- a/SoapyLMS7/SoapyLMS7.h
+++ b/SoapyLMS7/SoapyLMS7.h
@@ -16,7 +16,10 @@ static const double DEFAULT_CLOCK_RATE = 80e6;
 namespace lime
 {
     class LMS7002M;
+    struct StreamMetadata;
 }
+
+struct IConnectionStream;
 
 class SoapyLMS7 : public SoapySDR::Device
 {
@@ -80,6 +83,14 @@ public:
         int &flags,
         long long &timeNs,
         const long timeoutUs = 100000);
+
+    int _readStreamAligned(
+        IConnectionStream *stream,
+        char * const *buffs,
+        size_t numElems,
+        uint64_t requestTime,
+        lime::StreamMetadata &mdOut,
+        const long timeoutMs);
 
     int writeStream(
         SoapySDR::Stream *stream,

--- a/SoapyLMS7/Streaming.cpp
+++ b/SoapyLMS7/Streaming.cpp
@@ -286,7 +286,7 @@ int SoapyLMS7::_readStreamAligned(
     for (size_t i = 0; i < streamID.size(); first=false)
     {
         size_t &N = numWritten[i];
-        if (N == numElems) {i++; continue;} //channel already done
+        if (N == numElems) {i++; continue;} //this channel done, next channel
         const uint64_t expectedTime(requestTime + N);
 
         int status = _conn->ReadStream(streamID[i], buffs[i]+(elemSize*N), numElems-N, timeoutMs, md);
@@ -300,8 +300,8 @@ int SoapyLMS7::_readStreamAligned(
         //first read gets to decide maximum read size
         if (first) goto updateHead;
 
-        //good contiguous read, do the next index
-        if (expectedTime == md.timestamp) {i++; continue;}
+        //good contiguous read, read again for remainder
+        if (expectedTime == md.timestamp) continue;
 
         //request time is later, fast forward buffer
         if (md.timestamp < expectedTime)

--- a/SoapyLMS7/Streaming.cpp
+++ b/SoapyLMS7/Streaming.cpp
@@ -11,6 +11,7 @@
 #include <SoapySDR/Logger.hpp>
 #include <SoapySDR/Time.hpp>
 #include <thread>
+#include <iostream>
 #include <algorithm> //min/max
 #include "ErrorReporting.h"
 
@@ -257,6 +258,85 @@ int SoapyLMS7::deactivateStream(
 }
 
 /*******************************************************************
+ * Stream alignment helper for multiple channels
+ ******************************************************************/
+static inline void fastForward(
+    char *buff, size_t &numWritten, const size_t elemSize,
+    const uint64_t oldHeadTime, const uint64_t desiredHeadTime)
+{
+    const size_t numPop = std::min<size_t>(desiredHeadTime - oldHeadTime, numWritten);
+    const size_t numMove = (numWritten-numPop);
+    numWritten -= numPop;
+    std::memmove(buff, buff+(numPop*elemSize), numMove*elemSize);
+}
+
+int SoapyLMS7::_readStreamAligned(
+    IConnectionStream *stream,
+    char * const *buffs,
+    size_t numElems,
+    uint64_t requestTime,
+    StreamMetadata &md,
+    const long timeoutMs)
+{
+    const auto &streamID = stream->streamID;
+    const size_t elemSize = stream->elemSize;
+    std::vector<size_t> numWritten(streamID.size(), 0);
+    bool first = requestTime == 0;
+
+    for (size_t i = 0; i < streamID.size(); first=false)
+    {
+        size_t &N = numWritten[i];
+        if (N == numElems) {i++; continue;} //channel already done
+        const uint64_t expectedTime(requestTime + N);
+
+        int status = _conn->ReadStream(streamID[i], buffs[i]+(elemSize*N), numElems-N, timeoutMs, md);
+        if (status <= 0) return status; //timeout or other error
+
+        //update accounting
+        const size_t elemsRead = size_t(status);
+        const size_t prevN = N;
+        N += elemsRead; //num written total
+
+        //first read gets to decide maximum read size
+        if (first) goto updateHead;
+
+        //good contiguous read, do the next index
+        if (expectedTime == md.timestamp) {i++; continue;}
+
+        //request time is later, fast forward buffer
+        if (md.timestamp < expectedTime)
+        {
+            if (prevN != 0)
+            {
+                SoapySDR::log(SOAPY_SDR_ERROR, "readStream() experienced non-monotonic timestamp");
+                return SOAPY_SDR_STREAM_ERROR;
+            }
+            fastForward(buffs[i], N, elemSize, md.timestamp, requestTime);
+            continue; //read again into the remaining buffer
+        }
+
+        //overflow in the middle of a contiguous buffer
+        //fast-forward all prior channels and restart loop
+        if (md.timestamp > expectedTime)
+        {
+            for (size_t j = 0; j < i; j++)
+            {
+                fastForward(buffs[j], numWritten[j], elemSize, requestTime, md.timestamp);
+            }
+            fastForward(buffs[i], N, elemSize, md.timestamp-prevN, md.timestamp);
+        }
+
+        updateHead:
+        i = (i == 0)?1:0; //start over, unless this is the first index
+        requestTime = md.timestamp;
+        numElems = elemsRead;
+    }
+
+    md.timestamp = requestTime;
+    return int(numElems);
+}
+
+/*******************************************************************
  * Stream API
  ******************************************************************/
 int SoapyLMS7::readStream(
@@ -268,7 +348,6 @@ int SoapyLMS7::readStream(
     const long timeoutUs)
 {
     auto icstream = (IConnectionStream *)stream;
-    const auto &streamID = icstream->streamID;
 
     const auto exitTime = std::chrono::high_resolution_clock::now() + std::chrono::microseconds(timeoutUs);
 
@@ -288,33 +367,15 @@ int SoapyLMS7::readStream(
         numElems = std::min(numElems, icstream->elemMTU);
     }
 
-    ReadStreamAgain:
-
-    //read the 0th channel: get number of samples read and metadata
     StreamMetadata metadata;
-    int status = _conn->ReadStream(streamID[0], buffs[0], numElems, timeoutUs/1000, metadata);
+    const uint64_t cmdTicks = ((icstream->flags & SOAPY_SDR_HAS_TIME) != 0)?SoapySDR::timeNsToTicks(icstream->timeNs, _conn->GetHardwareTimestampRate()):0;
+    int status = _readStreamAligned(icstream, (char * const *)buffs, numElems, cmdTicks, metadata, timeoutUs/1000);
     if (status == 0) return SOAPY_SDR_TIMEOUT;
     if (status < 0) return SOAPY_SDR_STREAM_ERROR;
-
-    //read subsequent channels with the same size and large timeout
-    //we should always be able to get a matching buffer read quickly
-    //or there is an unknown internal issue with the stream fifo
-    for (size_t i = 1; i < streamID.size(); i++)
-    {
-        StreamMetadata metadata_i;
-        int status_i = _conn->ReadStream(streamID[i], buffs[i], status, 1000/*1s*/, metadata_i);
-        if (status_i != status or metadata_i.timestamp != metadata.timestamp)
-        {
-            SoapySDR::logf(SOAPY_SDR_ERROR, "Multi-channel stream alignment failed!");
-            return SOAPY_SDR_CORRUPTION;
-        }
-    }
 
     //the command had a time, so we need to compare it to received time
     if ((icstream->flags & SOAPY_SDR_HAS_TIME) != 0 and metadata.hasTimestamp)
     {
-        const uint64_t cmdTicks = SoapySDR::timeNsToTicks(icstream->timeNs, _conn->GetHardwareTimestampRate());
-
         //our request time is now late, clear command and return error code
         if (cmdTicks < metadata.timestamp)
         {
@@ -322,23 +383,16 @@ int SoapyLMS7::readStream(
             return SOAPY_SDR_TIME_ERROR;
         }
 
-        //our request time is not in this received buffer, try again
-        if (cmdTicks >= (metadata.timestamp + status))
+        //_readStreamAligned should guarantee this condition
+        if (cmdTicks != metadata.timestamp)
         {
-            if (std::chrono::high_resolution_clock::now() > exitTime) return SOAPY_SDR_TIMEOUT;
-            goto ReadStreamAgain;
+            SoapySDR::logf(SOAPY_SDR_ERROR,
+                "readStream() alignment algorithm failed\n"
+                "Request time = %lld, actual time = %lld",
+                (long long)cmdTicks, (long long)metadata.timestamp);
+            return SOAPY_SDR_STREAM_ERROR;
         }
 
-        //otherwise our request is in this buffer, advance memory
-        const size_t numOff = (cmdTicks - metadata.timestamp);
-        metadata.timestamp += numOff;
-        status -= numOff;
-        const size_t elemSize = icstream->elemSize;
-        for (size_t i = 0; i < streamID.size(); i++)
-        {
-            const size_t memStart = size_t(buffs[i])+(numOff*elemSize);
-            std::memmove(buffs[i], (const void *)memStart, status*elemSize);
-        }
         icstream->flags &= ~SOAPY_SDR_HAS_TIME; //clear for next read
     }
 

--- a/src/ConnectionSTREAM/ConnectionSTREAMing.cpp
+++ b/src/ConnectionSTREAM/ConnectionSTREAMing.cpp
@@ -313,20 +313,14 @@ void ConnectionSTREAM::ReceivePacketsLoop(Streamer* stream)
                 dest[c] = (chFrames[c].samples);
             int samplesCount = fpga::FPGAPacketPayload2Samples(pktStart, 4080, chCount==2, packed, dest.data());
 
-            int samplesToWrite = samplesCount;
-            uint32_t timeout_ms = 100;
             for(int ch=0; ch<chCount; ++ch)
             {
                 IStreamChannel::Metadata meta;
                 meta.timestamp = pkt[pktIndex].counter;
-                if (chCount == 1) meta.flags = IStreamChannel::Metadata::OVERWRITE_OLD; //no overwrite for mimo alignment mode
-                int samplesPushed = stream->mRxStreams[ch]->Write((const void*)chFrames[ch].samples, samplesToWrite, &meta, timeout_ms);
+                meta.flags = IStreamChannel::Metadata::OVERWRITE_OLD;
+                int samplesPushed = stream->mRxStreams[ch]->Write((const void*)chFrames[ch].samples, samplesCount, &meta, 100);
                 if(samplesPushed != samplesCount)
                     stream->mRxStreams[ch]->overflow++;
-
-                if (ch == 0) samplesToWrite = samplesPushed; //push the same amount on subsequent channels
-                else if (samplesToWrite != samplesPushed) lime::error("rx mimo alignment failure");
-                timeout_ms = 1000; //large timeout for subsequent channels
             }
         }
         // Re-submit this request to keep the queue full


### PR DESCRIPTION
The limesuite streams are independent and do not stay aligned in the presence of overflow. This change adds stream alignment to soapy lms readStream(). This ensures that all N channels are aligned to the same timestamp and contiguous when the readStream() call returns.

SoapyLMS users could also manually open and read from each stream individually and perform alignment outside of the SoapyLMS layer. This just implements alignment for the multiple channel configuration case -- which was the intention.

* no changes to limesuite api
* only soapylms layer changed
* resolves #141
* fyi @ccsh23