### PR TITLE
Fix proposal for issue #160

### DIFF
--- a/src/API/lms7_api.cpp
+++ b/src/API/lms7_api.cpp
@@ -70,8 +70,8 @@ API_EXPORT int CALL_CONV LMS_Open(lms_device_t** device, const lms_info_str_t in
 
     if (info == NULL)
     {
-        *device = LMS7_Device::CreateDevice(nullptr);
-        return LMS_SUCCESS;
+        lime::ReportError(ENODEV, "No default device available");
+        return -1;
     }
 
     lime::ReportError(ENODEV, "Specified device could not be found");


### PR DESCRIPTION
Fix proposal for issue #160 LMS_Open() not returning an error when opening default device and no device available.

If the original behavior of not returning an error was on purpose, for example to be able to run some unit tests without an actual hardware connected, I propose to create a specific _lms_info_str_t_ info dedicated for that purpose.