### PR TITLE
fix uLimeSDR USB interface claim

### DIFF
--- a/src/Connection_uLimeSDR/Connection_uLimeSDR.cpp
+++ b/src/Connection_uLimeSDR/Connection_uLimeSDR.cpp
@@ -235,12 +235,12 @@ int Connection_uLimeSDR::Open(const unsigned index, const int vid, const int pid
         if(libusb_detach_kernel_driver(dev_handle, 1) == 0) //detach it
             lime::debug("Kernel Driver Detached!");
     }
-    int r = libusb_claim_interface(dev_handle, 1); //claim interface 0 (the first) of device
+    int r = libusb_claim_interface(dev_handle, 0); //claim interface 0 (the first) of device
     if(r < 0)
     {
         return ReportError(-1, "Cannot claim interface - %s", libusb_strerror(libusb_error(r)));
     }
-    r = libusb_claim_interface(dev_handle, 1); //claim interface 0 (the first) of device
+    r = libusb_claim_interface(dev_handle, 1); //claim interface 1 (the second) of device
     if(r < 0)
     {
         return ReportError(-1, "Cannot claim interface - %s", libusb_strerror(libusb_error(r)));


### PR DESCRIPTION
This fixes a typo with the USB interface claim in uLimeSDR.
Symptoms on MacOS are a libusb warning for LimeSDR-USB
`Linux: usb: usbfs: process (LimeUtil) did not claim interface 0 before use`
and a crash for LimeSDR-mini
`libusb: warning [ep_to_pipeRef] no pipeRef found with endpoint address 0x01.`
`libusb: error [submit_bulk_transfer] endpoint not found on any open interface`
On Linux the problem isn't noticeable.