### PR TITLE
Fix CalibrateTxGain() XBUF settings for 3rd party boards

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,8 @@
+Release 18.06.1 (pending)
+==========================
+
+- Fix CalibrateTxGain() XBUF settings for 3rd party boards
+
 Release 18.06.0 (2018-06-13)
 ==========================
 

--- a/src/lms7002m/LMS7002M_gainCalibrations.cpp
+++ b/src/lms7002m/LMS7002M_gainCalibrations.cpp
@@ -59,9 +59,7 @@ int LMS7002M::CalibrateTxGainSetup()
     //do nothing
 
     //XBUF
-    Modify_SPI_Reg_bits(LMS7param(PD_XBUF_RX), 0);
-    Modify_SPI_Reg_bits(LMS7param(PD_XBUF_TX), 0);
-    Modify_SPI_Reg_bits(LMS7param(EN_G_XBUF), 1);
+    //use configured xbuf settings
 
     //CGEN
     SetDefaults(CGEN);


### PR DESCRIPTION
CalibrateTxGain was replaying the configured XBUF settings with potentially incompatible settings. The fix was to remove the XBUF changes and use the already configured settings from the board initialization. Please review.