### PR TITLE
Fix index lookup for opt_gain_tbb cache (ChB out of bounds)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -2,6 +2,7 @@ Release 18.06.1 (pending)
 ==========================
 
 - Fix CalibrateTxGain() XBUF settings for 3rd party boards
+- Fix index lookup for opt_gain_tbb cache (ChB out of bounds)
 
 Release 18.06.0 (2018-06-13)
 ==========================

--- a/src/lms7002m/LMS7002M.cpp
+++ b/src/lms7002m/LMS7002M.cpp
@@ -936,7 +936,7 @@ float_type LMS7002M::GetTRFLoopbackPAD_dB(void)
 
 int LMS7002M::SetTBBIAMP_dB(const float_type gain)
 {
-    int ind = Get_SPI_Reg_bits(LMS7_MAC);
+    int ind = this->GetActiveChannelIndex()%2;
     if (opt_gain_tbb[ind] <= 0)
     {
         if (CalibrateTxGain(0,nullptr)!=0) //set optimal BB gain
@@ -954,7 +954,7 @@ int LMS7002M::SetTBBIAMP_dB(const float_type gain)
 float_type LMS7002M::GetTBBIAMP_dB(void)
 {
     int g_current = Get_SPI_Reg_bits(LMS7param(CG_IAMP_TBB),true);
-    int ind = Get_SPI_Reg_bits(LMS7_MAC);
+    int ind = this->GetActiveChannelIndex()%2;
 
     if (opt_gain_tbb[ind] <= 0)
     {

--- a/src/lms7002m/LMS7002M_filtersCalibration.cpp
+++ b/src/lms7002m/LMS7002M_filtersCalibration.cpp
@@ -145,7 +145,7 @@ int LMS7002M::TuneTxFilter(const float_type tx_lpf_freq_RF)
             return ReportError(status, "Tune Tx Filter: failed to program MCU");
     }
 
-    int ind = Get_SPI_Reg_bits(LMS7_MAC);
+    int ind = this->GetActiveChannelIndex()%2;
     opt_gain_tbb[ind] = -1;
 
     //set reference clock parameter inside MCU

--- a/src/lms7002m/LMS7002M_gainCalibrations.cpp
+++ b/src/lms7002m/LMS7002M_gainCalibrations.cpp
@@ -119,7 +119,7 @@ int LMS7002M::CalibrateTxGain(float maxGainOffset_dBFS, float *actualGain_dBFS)
     }
     RestoreRegisterMap(registersBackup);
 
-    int ind = Get_SPI_Reg_bits(LMS7_MAC);
+    int ind = this->GetActiveChannelIndex()%2;
     opt_gain_tbb[ind] = cg_iamp > 1 ? cg_iamp-1 : 1;
 
     if (status == 0)


### PR DESCRIPTION
Using MAC means that the indexes were 1 and 2 for the two element array opt_gain_tbb.
Using GetActiveChannelIndex() provides 0 and 1 for an array index for ChA and ChB.