### PR TITLE
fix images download regex

### DIFF
--- a/cmake/DownloadImages.cmake
+++ b/cmake/DownloadImages.cmake
@@ -12,7 +12,7 @@ message(STATUS "## DOWNLOAD_IMAGES=${DOWNLOAD_IMAGES} specified; syncing images.
 message(STATUS "######################################################")
 
 #download support constants
-set(SOURCE_URL "http://downloads.myriadrf.org/project/limesuite/${VERSION_MAJOR}.${VERSION_MINOR}")
+set(SOURCE_URL "https://downloads.myriadrf.org/project/limesuite/${VERSION_MAJOR}.${VERSION_MINOR}")
 set(TEMP_DEST "${CMAKE_CURRENT_BINARY_DIR}/images/${VERSION_MAJOR}.${VERSION_MINOR}")
 set(INSTALL_DEST "share/LimeSuite/images/${VERSION_MAJOR}.${VERSION_MINOR}")
 set(HREF_MATCHER "href=\\\"/project/limesuite/${VERSION_MAJOR}.${VERSION_MINOR}/([\\._A-Za-z_0-9-]+(.rpd|.rbf|.img))\\\"")

--- a/cmake/DownloadImages.cmake
+++ b/cmake/DownloadImages.cmake
@@ -15,7 +15,7 @@ message(STATUS "######################################################")
 set(SOURCE_URL "http://downloads.myriadrf.org/project/limesuite/${VERSION_MAJOR}.${VERSION_MINOR}")
 set(TEMP_DEST "${CMAKE_CURRENT_BINARY_DIR}/images/${VERSION_MAJOR}.${VERSION_MINOR}")
 set(INSTALL_DEST "share/LimeSuite/images/${VERSION_MAJOR}.${VERSION_MINOR}")
-set(HREF_MATCHER "href=\\\"([\\._A-Za-z_0-9-]+)\\\"")
+set(HREF_MATCHER "href=\\\"/project/limesuite/${VERSION_MAJOR}.${VERSION_MINOR}/([\\._A-Za-z_0-9-]+(.rpd|.rbf|.img))\\\"")
 
 #conditional download when file is missing
 function(DOWNLOAD_URL url file)


### PR DESCRIPTION
the download page changed from plain directory listing to a more
complex page, with css and so on. Therefore we need a more restrictive
regex to get just image files.

patch done by @michaelld