### PR TITLE
long_options doesn't need to be static

### DIFF
--- a/QuickTest/TestGUI.cpp
+++ b/QuickTest/TestGUI.cpp
@@ -320,7 +320,7 @@ int main(int argc, char** argv)
 #else
     int gui = 1;
 #endif
-    static struct option long_options[] = {
+    struct option long_options[] = {
         {"gui", no_argument, &gui, 1},
         {"no-gui", no_argument, &gui, 0},
         {0, 0, 0, 0}


### PR DESCRIPTION
Without this change, [scan-build](https://clang-analyzer.llvm.org/scan-build.html) warns that the address of stack variable `gui` is being stored in a global variable.

Practically speaking, this doesn't really matter much since `main()` is only ever called once, but it's an easy fix and there's really no reason not to do it.