### PR TITLE
Fix power2unitsString compiler warnings

### DIFF
--- a/src/RFSpark/RFSpark_wxgui.cpp
+++ b/src/RFSpark/RFSpark_wxgui.cpp
@@ -26,47 +26,6 @@ const long RFSpark_wxgui::ID_CMBSELECTADC = wxNewId();
 BEGIN_EVENT_TABLE(RFSpark_wxgui, wxPanel)
 END_EVENT_TABLE()
 
-wxString power2unitsString(char powerx3)
-{
-	switch (powerx3)
-	{
-	case -8:
-		return "y";
-	case -7:
-		return "z";
-	case -6:
-		return "a";
-	case -5:
-		return "f";
-	case -4:
-		return "p";
-	case -3:
-		return "n";
-	case -2:
-		return "u";
-	case -1:
-		return "m";
-	case 0:
-		return "";
-	case 1:
-		return "k";
-	case 2:
-		return "M";
-	case 3:
-		return "G";
-	case 4:
-		return "T";
-	case 5:
-		return "P";
-	case 6:
-		return "E";
-	case 7:
-		return "Y";
-	default:
-		return "";
-	}
-}
-
 RFSpark_wxgui::RFSpark_wxgui(wxWindow* parent,wxWindowID id, const wxString& title, const wxPoint& pos,const wxSize& size, long style)
 {
     lmsControl = nullptr;

--- a/src/lms7002_wxgui/pnlBoardControls.cpp
+++ b/src/lms7002_wxgui/pnlBoardControls.cpp
@@ -27,7 +27,7 @@
 using namespace std;
 using namespace lime;
 
-static wxString power2unitsString(char powerx3)
+static wxString power2unitsString(int powerx3)
 {
     switch (powerx3)
     {


### PR DESCRIPTION
GCC was warning about unreachable cases, so I corrected the arg type to match the value being used in the only instance of this function.

I also removed the definition of this function from `RFSpark_wxgui.cpp`, since it was overriding the static function definition in `pnlBoardControls.cpp`, where it was actually being used.