### PR TITLE
Fix comparison between mismatched enums

### DIFF
--- a/src/API/LimeSDR_mini.cpp
+++ b/src/API/LimeSDR_mini.cpp
@@ -160,7 +160,7 @@ int LMS7_LimeSDR_mini::Calibrate(bool dir_tx, unsigned chan, double bw, unsigned
     uint16_t value = fpga->ReadRegister(0x17);
     uint16_t wr_val = value & (~0x3300);
     wr_val |= lms_list[0]->GetBandTRF() == LMS_PATH_TX2 ? 0x1000 : 0x2000;
-    wr_val |= lms_list[0]->GetPathRFE() == LMS_PATH_LNAW ?  0x100 : 0x200;
+    wr_val |= lms_list[0]->GetPathRFE() == LMS7002M::PathRFE::PATH_RFE_LNAW ?  0x100 : 0x200;
     fpga->WriteRegister(0x17, wr_val);
     int ret = LMS7_Device::Calibrate(dir_tx, chan, bw, flags);
     fpga->WriteRegister(0x17, value);


### PR DESCRIPTION
This fixes the following warning:

```
src/API/LimeSDR_mini.cpp: In member function ‘virtual int lime::LMS7_LimeSDR_mini::Calibrate(bool, unsigned int, double, unsigned int)’:
src/API/LimeSDR_mini.cpp:163:44: warning: comparison between ‘enum lime::LMS7002M::PathRFE’ and ‘enum<unnamed>’ [-Wenum-compare]
     wr_val |= lms_list[0]->GetPathRFE() == LMS_PATH_LNAW ?  0x100 : 0x200;
                                            ^~~~~~~~~~~~~
```

This still worked because the enums it was comparing between happened to have the same value for the LNAW path, but comparing raw values between enums is generally not a good idea because in doing so you lose all the benefits of type-checking.