### PR TITLE
oglGraph: fix size with Retina display

### DIFF
--- a/src/oglGraph/OpenGLGraph.cpp
+++ b/src/oglGraph/OpenGLGraph.cpp
@@ -176,8 +176,8 @@ void OpenGLGraph::Resize(int w, int h)
 {
   if(w <= 0 || h <=0 )
     return;
-  settings.windowWidth = w;
-  settings.windowHeight = h;
+  settings.windowWidth = w * GetContentScaleFactor();
+  settings.windowHeight = h * GetContentScaleFactor();
   settings.dataViewHeight = settings.windowHeight-settings.marginTop-settings.marginBottom;
   if(settings.dataViewHeight <= 0)
     settings.dataViewHeight = 1;


### PR DESCRIPTION
fix openGL grpah size with Retina (HighDPi) display.

Maybe we should fix the font size also; particulary in the axis but it is not enough to change this
```
diff --git a/src/oglGraph/OpenGLGraph.cpp b/src/oglGraph/OpenGLGraph.cpp
index d1d3cab6..57f02bb2 100644
--- a/src/oglGraph/OpenGLGraph.cpp
+++ b/src/oglGraph/OpenGLGraph.cpp
@@ -769,7 +769,7 @@ GLvoid OpenGLGraph::glRenderText(float posx, float posy, float angle, float scal
        //if font has been loaded
        glEnable(GL_TEXTURE_2D);
        if(m_font != NULL)
-            m_font->render_textWorldSpace(text, 0, 0, scale, rgba);
+            m_font->render_textWorldSpace(text, 0, 0, scale * GetContentScaleFactor(), rgba);

        glPopMatrix();
     glDisable(GL_TEXTURE_2D);
```
because we need to resize the free space on the graph borders.