### PR TITLE
Fixed issue of file closing function not being called after absdfs re…

### DIFF
--- a/src/fftviewer_wxgui/fftviewer_frFFTviewer.cpp
+++ b/src/fftviewer_wxgui/fftviewer_frFFTviewer.cpp
@@ -582,6 +582,7 @@ void fftviewer_frFFTviewer::StreamingLoop(fftviewer_frFFTviewer* pthis, const un
             }
             fout << endl;
         }
+        fout.close();
     }
 
     kiss_fft_free(m_fftCalcPlan);


### PR DESCRIPTION
…adings are captured in the FFT panel. This causes the system to hang or respond extremely slow