### PR TITLE
Protocols: fix null pointer dereference in the Read member function

### DIFF
--- a/src/protocols/Streamer.cpp
+++ b/src/protocols/Streamer.cpp
@@ -80,16 +80,19 @@ int StreamChannel::Read(void* samples, const uint32_t count, Metadata* meta, con
         complex16_t* ptr = (complex16_t*)samples;
         int16_t* samplesShort = (int16_t*)samples;
         float* samplesFloat = (float*)samples;
-        popped = fifo->pop_samples(ptr, count, &meta->timestamp, timeout_ms);
+        popped = fifo->pop_samples(ptr, count, meta ? &meta->timestamp : nullptr, timeout_ms);
         for(int i=2*popped-1; i>=0; --i)
             samplesFloat[i] = (float)samplesShort[i]/32767.0f;
     }
     else
     {
         complex16_t* ptr = (complex16_t*)samples;
-        popped = fifo->pop_samples(ptr, count, &meta->timestamp, timeout_ms);
+        popped = fifo->pop_samples(ptr, count, meta ? &meta->timestamp : nullptr, timeout_ms);
     }
-    meta->flags |= RingFIFO::SYNC_TIMESTAMP;
+    if(meta)
+    {
+        meta->flags |= RingFIFO::SYNC_TIMESTAMP;
+    }
     return popped;
 }
 

--- a/src/protocols/Streamer.cpp
+++ b/src/protocols/Streamer.cpp
@@ -60,13 +60,13 @@ int StreamChannel::Write(const void* samples, const uint32_t count, const Metada
         for(size_t i=0; i<2*count; ++i)
             samplesShort[i] = samplesFloat[i]*32767.0f;
         const complex16_t* ptr = (const complex16_t*)samplesShort ;
-        pushed = fifo->push_samples(ptr, count, meta->timestamp, timeout_ms, meta->flags);
+        pushed = fifo->push_samples(ptr, count, meta ? meta->timestamp : 0, timeout_ms, meta ? meta->flags : 0);
         delete[] samplesShort;
     }
     else
     {
         const complex16_t* ptr = (const complex16_t*)samples;
-        pushed = fifo->push_samples(ptr, count, meta->timestamp, timeout_ms, meta->flags);
+        pushed = fifo->push_samples(ptr, count, meta ? meta->timestamp : 0, timeout_ms, meta ? meta->flags : 0);
     }
     return pushed;
 }


### PR DESCRIPTION
Fix NULL-pointer dereference in the `Read` member function. This
function is protected from this problem in case of and indirect call
via `LMS_RecvStream` function, but in case of direct call the problem
may occur.

Note that the `Write` function isn't fixed!

Test: create a `StreamChannel` instance, call the `Read` function and