### PR TITLE
Allow compilation with wxWidgets STL build

### DIFF
--- a/src/limeRFE/limeRFE_wxgui.cpp
+++ b/src/limeRFE/limeRFE_wxgui.cpp
@@ -126,7 +126,10 @@ void limeRFE_wxgui::OnbtnClosePort(wxCommandEvent& event) {
 
 void limeRFE_wxgui::AddMssg(const char* mssg) {
 	wxString s(mssg, wxConvUTF8);
+	AddMssg(s);
+}
 
+void limeRFE_wxgui::AddMssg(const wxString& mssg) {
 	time_t rawtime;
 	struct tm * timeinfo;
 	char buffer[80];
@@ -134,7 +137,7 @@ void limeRFE_wxgui::AddMssg(const char* mssg) {
 	time(&rawtime);
 	timeinfo = localtime(&rawtime);
 	strftime(buffer, 80, "%H:%M:%S", timeinfo);
-	wxString line(wxString::Format("[%s] %s", buffer, s));
+	wxString line(wxString::Format("[%s] %s", buffer, mssg));
 
 	txtMessageField->AppendText(line + _("\n"));
 }

--- a/src/limeRFE/limeRFE_wxgui.h
+++ b/src/limeRFE/limeRFE_wxgui.h
@@ -25,6 +25,7 @@ class limeRFE_wxgui : public limeRFE_view
 		void OnbtnOpenPort(wxCommandEvent& event);
 		void OnbtnClosePort(wxCommandEvent& event);
 		void AddMssg(const char* mssg);
+		void AddMssg(const wxString& mssg);
 		void ReadPorts();
 		void OnbtnRefreshPorts(wxCommandEvent& event);
 		void OnbtnReset(wxCommandEvent& event);


### PR DESCRIPTION
wxString may not be implicitly convertible to const char*, so add an
overload.