### PR TITLE
Fix a wrong frequency value in comments

### DIFF
--- a/src/examples/dualRXTX.cpp
+++ b/src/examples/dualRXTX.cpp
@@ -69,7 +69,7 @@ int main(int argc, char** argv)
         error();
     if (LMS_SetLOFrequency(device, LMS_CH_RX, 1, 1e9) != 0)
         error();
-    //Set TX center frequency to 1 GHz
+    //Set TX center frequency to 1.2 GHz
     //Automatically selects antenna port
     if (LMS_SetLOFrequency(device, LMS_CH_TX, 0, 1.2e9) != 0)
         error();


### PR DESCRIPTION
At first glance it is unclear where is the error in the comments or in
the code. Until the real intention is not known it looks like an error
in the code where 1.2GHz is used instead of 1.0GHz.

The desired behavior can be found in the documentation (Pg. 18 of the
docs/lms7_api_quick_start_guide.pdf, para: 3.3.2 Device configuration:
"The Rx frequency for both channels is set to 1 GHz while Tx frequency
is set to 1.2 GHz."