### PR TITLE
Remove redundant temporary variable.

### DIFF
--- a/src/protocols/LMS64CProtocol.cpp
+++ b/src/protocols/LMS64CProtocol.cpp
@@ -388,9 +388,8 @@ int LMS64CProtocol::TransferPacket(GenericPacket& pkt)
             break;
         }
         outBufPos += packetLen;
-        long readLen = packetLen;
-        int bread = Read(&inBuffer[inDataPos], readLen);
-        if(bread != readLen)
+        int bread = Read(&inBuffer[inDataPos], packetLen);
+        if(bread != packetLen)
         {
             status = lime::error("TransferPacket: Read failed (ret=%d)", bread);
             break;


### PR DESCRIPTION
Just a minor cosmetic fix.

P.S. moreover the ```readLen``` should be ```int``` instead of ```long```.