### PR TITLE
Get an associated timestamps (HW clock and host OS time).

### DIFF
--- a/src/API/lms7_device.cpp
+++ b/src/API/lms7_device.cpp
@@ -1867,6 +1867,11 @@ void LMS7_Device::SetHardwareTimestamp(const uint64_t now)
     mStreamers[0]->SetHardwareTimestamp(now);
 }
 
+void LMS7_Device::GetRelativeTimestamp(uint64_t &hw_time, host_time_t &host_time) const
+{
+    mStreamers[0]->GetRelativeTimestamp(hw_time, host_time);
+}
+
 int LMS7_Device::MCU_AGCStart(uint32_t wantedRSSI)
 {
     lime::MCU_BD *mcu = lms_list.at(lms_chip_id)->GetMCUControls();

--- a/src/API/lms7_device.h
+++ b/src/API/lms7_device.h
@@ -94,6 +94,7 @@ public:
     int DestroyStream(lime::StreamChannel* streamID);
     uint64_t GetHardwareTimestamp(void) const;
     void SetHardwareTimestamp(const uint64_t now);
+    void GetRelativeTimestamp(uint64_t &, host_time_t &) const;
 
     int MCU_AGCStart(uint32_t wantedRSSI);
     int MCU_AGCStop();

--- a/src/ConnectionFTDI/ConnectionFT601.cpp
+++ b/src/ConnectionFTDI/ConnectionFT601.cpp
@@ -495,7 +495,7 @@ bool ConnectionFT601::WaitForReading(int contextHandle, unsigned int timeout_ms)
 @param contextHandle handle of which context to finish
 @return false failure, true number of bytes received
 */
-int ConnectionFT601::FinishDataReading(char *buffer, uint32_t length, int contextHandle)
+int ConnectionFT601::FinishDataReading(char *buffer, uint32_t length, int contextHandle, host_time_t * ht)
 {
     if(contextHandle >= 0 && contexts[contextHandle].used == true)
     {

--- a/src/ConnectionFTDI/ConnectionFT601.h
+++ b/src/ConnectionFTDI/ConnectionFT601.h
@@ -90,7 +90,7 @@ protected:
     int CheckStreamSize(int size) const override;
     int BeginDataReading(char* buffer, uint32_t length, int ep) override;
     bool WaitForReading(int contextHandle, unsigned int timeout_ms) override;
-    int FinishDataReading(char* buffer, uint32_t length, int contextHandle) override;
+    int FinishDataReading(char* buffer, uint32_t length, int contextHandle, host_time_t * ht = nullptr) override;
     void AbortReading(int ep) override;
 
     int BeginDataSending(const char* buffer, uint32_t length, int ep) override;

--- a/src/ConnectionFX3/ConnectionFX3.cpp
+++ b/src/ConnectionFX3/ConnectionFX3.cpp
@@ -418,6 +418,7 @@ void callback_libusbtransfer(libusb_transfer *trans)
         break;
     case LIBUSB_TRANSFER_COMPLETED:
         context->bytesXfered = trans->actual_length;
+        context->ht = std::chrono::time_point_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
         context->done.store(true);
         break;
     case LIBUSB_TRANSFER_ERROR:
@@ -524,10 +525,11 @@ bool ConnectionFX3::WaitForReading(int contextHandle, unsigned int timeout_ms)
 	@param contextHandle handle of which context to finish
 	@return negative values failure, positive number of bytes received
 */
-int ConnectionFX3::FinishDataReading(char *buffer, uint32_t length, int contextHandle)
+int ConnectionFX3::FinishDataReading(char *buffer, uint32_t length, int contextHandle, host_time_t * ht)
 {
     if(contextHandle >= 0 && contexts[contextHandle].used == true)
     {
+    if (ht) * ht = contexts[contextHandle].ht;
     #ifndef __unix__
     int status = 0;
     long len = length;

--- a/src/ConnectionFX3/ConnectionFX3.h
+++ b/src/ConnectionFX3/ConnectionFX3.h
@@ -80,6 +80,7 @@ public:
     std::mutex transferLock;
     std::condition_variable cv;
 #endif
+    host_time_t ht;
 };
 
 class ConnectionFX3 : public LMS64CProtocol
@@ -106,7 +107,7 @@ protected:
 
     int BeginDataReading(char* buffer, uint32_t length, int ep) override;
     bool WaitForReading(int contextHandle, unsigned int timeout_ms) override;
-    int FinishDataReading(char* buffer, uint32_t length, int contextHandle) override;
+    int FinishDataReading(char* buffer, uint32_t length, int contextHandle, host_time_t * ht = nullptr) override;
     void AbortReading(int ep) override;
 
     int BeginDataSending(const char* buffer, uint32_t length, int ep) override;

--- a/src/ConnectionRegistry/IConnection.cpp
+++ b/src/ConnectionRegistry/IConnection.cpp
@@ -102,7 +102,7 @@ bool IConnection::WaitForReading(int contextHandle, unsigned int timeout_ms)
 {
     return true;
 }
-int IConnection::FinishDataReading(char* buffer, uint32_t length, int contextHandle)
+int IConnection::FinishDataReading(char* buffer, uint32_t length, int contextHandle, host_time_t * ht)
 {
     return 0;
 }

--- a/src/ConnectionRegistry/IConnection.h
+++ b/src/ConnectionRegistry/IConnection.h
@@ -58,6 +58,11 @@ struct LIME_API DeviceInfo
 };
 
 /*!
+ * Convenient type alias for fast and comprehensive switching between underlying types.
+ */
+using host_time_t = uint64_t;
+
+/*!
  * IConnection is the interface class for a device with 1 or more Lime RFICs.
  * The LMS7002M driver class calls into IConnection to interface with the hardware
  * to implement high level functions on top of low-level SPI and GPIO.
@@ -157,23 +162,24 @@ public:
     @param length       number of bytes to read
     @param epIndex      endpoint identifier?
     @param timeout_ms   timeout in milliseconds
+    @param ht [out]     host timestamp associated with the last sample
     */
     virtual int ResetStreamBuffers();
     virtual int GetBuffersCount()const;
     virtual int CheckStreamSize(int size)const;
     virtual int ReceiveData(char* buffer, int length, int epIndex, int timeout = 100);
     virtual int SendData(const char* buffer, int length, int epIndex, int timeout = 100);
-    
+
     virtual int BeginDataSending(const char* buffer, uint32_t length, int ep);
     virtual bool WaitForSending(int contextHandle, uint32_t timeout_ms);
     virtual int FinishDataSending(const char* buffer, uint32_t length, int contextHandle);
     virtual void AbortSending(int ep){};
-    
+
     virtual int BeginDataReading(char* buffer, uint32_t length, int ep);
     virtual bool WaitForReading(int contextHandle, unsigned int timeout_ms);
-    virtual int FinishDataReading(char* buffer, uint32_t length, int contextHandle);
+    virtual int FinishDataReading(char* buffer, uint32_t length, int contextHandle, host_time_t * ht = nullptr);
     virtual void AbortReading(int ep){};
-    
+
     /***********************************************************************
      * Programming API
      **********************************************************************/

--- a/src/ConnectionXillybus/ConnectionXillybus.cpp
+++ b/src/ConnectionXillybus/ConnectionXillybus.cpp
@@ -656,7 +656,7 @@ bool ConnectionXillybus::WaitForReading(int contextHandle, unsigned int timeout_
 {
     return true;
 }
-int ConnectionXillybus::FinishDataReading(char* buffer, uint32_t length, int contextHandle)
+int ConnectionXillybus::FinishDataReading(char* buffer, uint32_t length, int contextHandle, host_time_t * ht)
 {
     return ReceiveData(buffer, length, contextHandle, 3000);
 }

--- a/src/ConnectionXillybus/ConnectionXillybus.h
+++ b/src/ConnectionXillybus/ConnectionXillybus.h
@@ -49,7 +49,7 @@ protected:
 
     int BeginDataReading(char* buffer, uint32_t length, int ep) override;
     bool WaitForReading(int contextHandle, unsigned int timeout_ms) override;
-    int FinishDataReading(char* buffer, uint32_t length, int contextHandle) override;
+    int FinishDataReading(char* buffer, uint32_t length, int contextHandle, host_time_t * ht = nullptr) override;
     void AbortReading(int epIndex);
 
     int BeginDataSending(const char* buffer, uint32_t length, int ep) override;

--- a/src/protocols/Streamer.cpp
+++ b/src/protocols/Streamer.cpp
@@ -302,7 +302,7 @@ void Streamer::SetHardwareTimestamp(const uint64_t now)
 
 void Streamer::GetRelativeTimestamp(uint64_t &hw_time, host_time_t &host_time) const
 {
-    std::lock_guard<std::mutex> l (rtlock);
+    std::lock_guard<Spin> l (rtlock);
     hw_time = rxLastTimestamp.load(std::memory_order_relaxed);
     host_time = rxLastHosttime.load(std::memory_order_relaxed);
 }
@@ -884,7 +884,7 @@ void Streamer::ReceivePacketsLoop()
                         value.pktLost += packetLoss;
             }
             prevTs = pkt[pktIndex].counter;
-            std::unique_lock<std::mutex> l (rtlock);
+            std::unique_lock<Spin> l (rtlock);
             rxLastTimestamp.store(prevTs, std::memory_order_relaxed);
             rxLastHosttime.store(ht, std::memory_order_relaxed);
             l.unlock();

--- a/src/protocols/Streamer.cpp
+++ b/src/protocols/Streamer.cpp
@@ -182,6 +182,7 @@ Streamer::Streamer(FPGA* f, LMS7002M* chip, int id) : mRxStreams(2, this), mTxSt
     dataPort = f->GetConnection();
     mTimestampOffset = 0;
     rxLastTimestamp.store(0, std::memory_order_relaxed);
+    rxLastHosttime.store(0, std::memory_order_relaxed);
     terminateRx.store(false, std::memory_order_relaxed);
     terminateTx.store(false, std::memory_order_relaxed);
     rxDataRate_Bps.store(0, std::memory_order_relaxed);
@@ -297,6 +298,13 @@ uint64_t Streamer::GetHardwareTimestamp(void)
 void Streamer::SetHardwareTimestamp(const uint64_t now)
 {
     mTimestampOffset = now - rxLastTimestamp.load(std::memory_order_relaxed);
+}
+
+void Streamer::GetRelativeTimestamp(uint64_t &hw_time, host_time_t &host_time) const
+{
+    std::lock_guard<std::mutex> l (rtlock);
+    hw_time = rxLastTimestamp.load(std::memory_order_relaxed);
+    host_time = rxLastHosttime.load(std::memory_order_relaxed);
 }
 
 void Streamer::RstRxIQGen()
@@ -835,11 +843,12 @@ void Streamer::ReceivePacketsLoop()
     while (terminateRx.load(std::memory_order_relaxed) == false)
     {
         int32_t bytesReceived = 0;
+        host_time_t ht;
         if(handles[bi] >= 0)
         {
             if (dataPort->WaitForReading(handles[bi], 1000) == true)
             {
-                bytesReceived = dataPort->FinishDataReading(&buffers[bi*bufferSize], bufferSize, handles[bi]);
+                bytesReceived = dataPort->FinishDataReading(&buffers[bi*bufferSize], bufferSize, handles[bi], &ht);
                 totalBytesReceived += bytesReceived;
             }
             else
@@ -875,7 +884,10 @@ void Streamer::ReceivePacketsLoop()
                         value.pktLost += packetLoss;
             }
             prevTs = pkt[pktIndex].counter;
+            std::unique_lock<std::mutex> l (rtlock);
             rxLastTimestamp.store(prevTs, std::memory_order_relaxed);
+            rxLastHosttime.store(ht, std::memory_order_relaxed);
+            l.unlock();
             //parse samples
             std::vector<complex16_t*> dest(chCount);
             for(uint8_t c=0; c<chCount; ++c)

--- a/src/protocols/Streamer.h
+++ b/src/protocols/Streamer.h
@@ -27,6 +27,11 @@ class Streamer;
 class LMS7002M;
 
 /*!
+ * Type alias redefinition. Must be aligned with the IConnection.h.
+ */
+using host_time_t = uint64_t;
+
+/*!
  * The stream config structure is used with the SetupStream() API.
  */
 struct LIME_API StreamConfig
@@ -123,6 +128,7 @@ public:
 
     uint64_t GetHardwareTimestamp(void);
     void SetHardwareTimestamp(const uint64_t now);
+    void GetRelativeTimestamp(uint64_t &, host_time_t &) const;
     int UpdateThreads(bool stopAll = false);
 
     std::atomic<uint32_t> rxDataRate_Bps;
@@ -137,6 +143,8 @@ public:
     std::vector<StreamChannel> mTxStreams;
     std::atomic<uint64_t> rxLastTimestamp;
     std::atomic<uint64_t> txLastTimestamp;
+    std::atomic<host_time_t> rxLastHosttime;
+    mutable std::mutex rtlock;
     uint64_t mTimestampOffset;
     int streamSize;
     unsigned txBatchSize;

--- a/src/protocols/Streamer.h
+++ b/src/protocols/Streamer.h
@@ -117,6 +117,22 @@ protected:
 
 };
 
+/*!
+ * A trivial implementation of the Spinlock which satisfies the Lockable concept requirements.
+ */
+class Spin
+{
+public:
+    Spin() = default;
+    Spin(const Spin&) = delete;
+    Spin& operator= (const Spin&) = delete;
+    void lock() {while (spin.test_and_set(std::memory_order_acquire));}
+    bool try_lock() {return !spin.test_and_set(std::memory_order_acquire);}
+    void unlock() {spin.clear(std::memory_order_release);}
+private:
+    std::atomic_flag spin {ATOMIC_FLAG_INIT};
+};
+
 class Streamer
 {
 public:
@@ -144,7 +160,7 @@ public:
     std::atomic<uint64_t> rxLastTimestamp;
     std::atomic<uint64_t> txLastTimestamp;
     std::atomic<host_time_t> rxLastHosttime;
-    mutable std::mutex rtlock;
+    mutable Spin rtlock;
     uint64_t mTimestampOffset;
     int streamSize;
     unsigned txBatchSize;


### PR DESCRIPTION
Hello everyone,

I work with a system with several sensors. LimeSDR is one of them. For proper data processing and data fusion, I need to associate data from LimeSDR and other sensors.

To solve this task I decided to use timestamps. But the current LimeSDR API provides only HW timestamps that have local meaning and can't be used for data association between different systems (processes).

I've prepared a draft version of changes that provide the mentioned above functionality. I would be grateful for the review and feedback. Note that only "add function to obtain a host time associated with samples" is a key commit, but others are auxiliary ones. I understood that this is a quite specific requirement that doesn't need for other users and it shouldn't be merged into the mainline repository, but anyway I would be grateful for any comments regarding the provided solution.

Probably there is an existed solution or the better one may be implemented?