### PR TITLE
Fix configuration of the Octave plugin in static libraries mode

### DIFF
--- a/octave/CMakeLists.txt
+++ b/octave/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 add_custom_command(OUTPUT LimeSuite.oct LimeSuite.o
     ALL
     COMMAND ${OCTAVE_MKOCTFILE_EXECUTABLE}
-    ARGS -I${PROJECT_SOURCE_DIR}/src/lime ${CMAKE_CURRENT_SOURCE_DIR}/LimeSuite.cc -L$<TARGET_SONAME_FILE_DIR:LimeSuite> -lLimeSuite
+    ARGS -I${PROJECT_SOURCE_DIR}/src/lime ${CMAKE_CURRENT_SOURCE_DIR}/LimeSuite.cc -L$<TARGET_FILE_DIR:LimeSuite> -lLimeSuite
     COMMENT "Building LimeSuite Octave plugin"
     DEPENDS LimeSuite
 )


### PR DESCRIPTION
Fix configuration of the Octave plugin with static LimeSuite library (with `BUILD_SHARED_LIBS=OFF` option).

See commit message for details.