### PR TITLE
Fixed Stream Unite entry build.

### DIFF
--- a/src/ConnectionSTREAM_UNITE/ConnectionSTREAM_UNITEEntry.cpp
+++ b/src/ConnectionSTREAM_UNITE/ConnectionSTREAM_UNITEEntry.cpp
@@ -16,7 +16,7 @@ static ConnectionSTREAM_UNITEEntry STREAM_UNITEEntry;
 }
 
 ConnectionSTREAM_UNITEEntry::ConnectionSTREAM_UNITEEntry(void):
-    ConnectionFX3Entry("STREAM+UNITE")
+    ConnectionFX3Entry()
 {
 
 }


### PR DESCRIPTION
ConnectionFX3Entry(void) does not accept parameters.

Signed-off-by: Tomasz 'CeDeROM' CEDRO <tomek@cedro.info>