### PR TITLE
Fixed Stream Unite headers build problem.

### DIFF
--- a/src/ConnectionSTREAM_UNITE/ConnectionSTREAM_UNITE.cpp
+++ b/src/ConnectionSTREAM_UNITE/ConnectionSTREAM_UNITE.cpp
@@ -5,7 +5,6 @@
 */
 
 #include "ConnectionSTREAM_UNITE.h"
-#include "ErrorReporting.h"
 using namespace std;
 namespace lime
 {


### PR DESCRIPTION
"ErrorReporting.h" does not seem to be a part of the code anymore.

Signed-off-by: Tomasz 'CeDeROM' CEDRO <tomek@cedro.info>