### PR TITLE
Added SIMD exception for RV64 targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,13 @@ else()
     set(X86 FALSE)
 endif()
 
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64")
+        set(RV64 TRUE)
+else()
+        set(RV64 FALSE)
+endif()
+
+
 if(CMAKE_COMPILER_IS_GNUCXX)
 
     #enable C++11 on older versions of cmake
@@ -115,6 +122,9 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     endif()
     if ("${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr" AND X86)
         set(DEFAULT_SIMD_FLAGS "SSE3")
+    endif()
+    if(RV64)
+        set(DEFAULT_SIMD_FLAGS "rv64")
     endif()
 
     SET(ENABLE_SIMD_FLAGS "${DEFAULT_SIMD_FLAGS}" CACHE STRING "Set compiler SIMD flags")


### PR DESCRIPTION
That enables compiling LimeSuite in boards like SiFive Unmatched and Beagle V. For some reason riscv64-gcc does not support `-march=native` and needs to be explicit told to use `-march=rv64`.

So I added an exception and now works on my Beagle V board:
![image](https://user-images.githubusercontent.com/578310/120690339-77829480-c47b-11eb-9681-350b9de96b42.png)
