### PR TITLE
Add LimeUtil option to set and enable external reference on ADF4002

### DIFF
--- a/LimeUtil/LimeUtil.cpp
+++ b/LimeUtil/LimeUtil.cpp
@@ -210,6 +210,11 @@ static int enableExtRefClk(const std::string &argStr, const double fref, const d
         return EXIT_FAILURE;
     }
 
+    uint16_t adfLocked = 0;
+    conn->ReadRegister(0x00c8, adfLocked);
+    adfLocked = adfLocked >> 1;
+    std::cout << "  ADF4002 Lock State: " << adfLocked << std::endl << std::flush;
+
     std::cout << "  Free connection... " << std::flush;
     ConnectionRegistry::freeConnection(conn);
     std::cout << "OK" << std::endl;


### PR DESCRIPTION
This allows command line enabling of the external reference port REF_CLK_IN on LimeSDR-USB in a similar manner as the ADF4002 dialog in LimeSuite. Seems useful for enabling a GPSDO on headless deployments. Also contains code to query and display the current lock state (0/1).