### PR TITLE
soapy: enable access to the latency parameter

### DIFF
--- a/SoapyLMS7/Streaming.cpp
+++ b/SoapyLMS7/Streaming.cpp
@@ -69,6 +69,17 @@ SoapySDR::ArgInfoList SoapyLMS7::getStreamArgsInfo(const int direction, const si
         argInfos.push_back(info);
     }
 
+    //latency
+    {
+        SoapySDR::ArgInfo info;
+        info.value = "0.5";
+        info.key = "latency";
+        info.name = "Latency";
+        info.description = "Latency vs. performance";
+        info.type = SoapySDR::ArgInfo::FLOAT;
+        argInfos.push_back(info);
+    }
+
     //link format
     {
         SoapySDR::ArgInfo info;


### PR DESCRIPTION
There is already code to parse the option, but it was not declared in the list of options the driver supports.

The limited size of USB transfers is significantly affecting performance on a RaspberryPi 4 running 64 bit Ubuntu 20.04. Without increasing the size I'm regularly seeing samples being lost (gr-soapy is not reporting this because it does not call `readStreamStatus()`).