### PR TITLE
Allow settings external reference clock from Soapy

### DIFF
--- a/SoapyLMS7/Settings.cpp
+++ b/SoapyLMS7/Settings.cpp
@@ -592,6 +592,12 @@ double SoapyLMS7::getMasterClockRate(void) const
     return lms7Device->GetClockFreq(LMS_CLOCK_CGEN);
 }
 
+void SoapyLMS7::setReferenceClockRate(const double rate)
+{
+    std::unique_lock<std::recursive_mutex> lock(_accessMutex);
+    lms7Device->SetClockFreq(LMS_CLOCK_EXTREF, rate);
+}
+
 /*******************************************************************
  * Time API
  ******************************************************************/

--- a/SoapyLMS7/Settings.cpp
+++ b/SoapyLMS7/Settings.cpp
@@ -592,10 +592,39 @@ double SoapyLMS7::getMasterClockRate(void) const
     return lms7Device->GetClockFreq(LMS_CLOCK_CGEN);
 }
 
-void SoapyLMS7::setReferenceClockRate(const double rate)
+std::string SoapyLMS7::getClockSource(void) const {
+    return _clockExternal ? "external" : "internal";
+}
+
+double SoapyLMS7::getReferenceClockRate(void) const {
+    return _clockExternal ? _clockRate : 0.0f;
+}
+
+SoapySDR::RangeList SoapyLMS7::getReferenceClockRates(void) const {
+    std::unique_lock<std::recursive_mutex> lock(_accessMutex);
+    SoapySDR::RangeList result;
+    result.emplace_back(0, lms7Device->GetClockFreq(LMS_CLOCK_REF));
+    return result;
+}
+
+std::vector<std::string> SoapyLMS7::listClockSources(void) const {
+    return {"internal", "external"};
+}
+
+void SoapyLMS7::setClockSource(const std::string &source) {
+    _clockExternal = source == "external";
+    updateReferenceClock();
+}
+
+void SoapyLMS7::setReferenceClockRate(const double rate) {
+    _clockRate = std::max(0.0, rate);
+    updateReferenceClock();
+}
+
+void SoapyLMS7::updateReferenceClock()
 {
     std::unique_lock<std::recursive_mutex> lock(_accessMutex);
-    lms7Device->SetClockFreq(LMS_CLOCK_EXTREF, rate);
+    lms7Device->SetClockFreq(LMS_CLOCK_EXTREF, _clockExternal ? _clockRate : 0.0);
 }
 
 /*******************************************************************

--- a/SoapyLMS7/SoapyLMS7.h
+++ b/SoapyLMS7/SoapyLMS7.h
@@ -205,6 +205,8 @@ public:
 
     double getMasterClockRate(void) const;
 
+    void setReferenceClockRate(const double rate);
+
     /*******************************************************************
      * Time API
      ******************************************************************/

--- a/SoapyLMS7/SoapyLMS7.h
+++ b/SoapyLMS7/SoapyLMS7.h
@@ -205,6 +205,16 @@ public:
 
     double getMasterClockRate(void) const;
 
+    std::string getClockSource(void) const;
+
+    double getReferenceClockRate(void) const;
+
+    SoapySDR::RangeList getReferenceClockRates(void) const;
+
+    std::vector<std::string> listClockSources(void) const;
+
+    void setClockSource(const std::string &source);
+
     void setReferenceClockRate(const double rate);
 
     /*******************************************************************
@@ -290,6 +300,7 @@ private:
     };
 
     int setBBLPF(bool direction, size_t channel, double bw);
+    void updateReferenceClock();
 
     const SoapySDR::Kwargs _deviceArgs; //!< stash of constructor arguments
     const std::string _moduleName;
@@ -300,4 +311,6 @@ private:
     mutable std::recursive_mutex _accessMutex;
     std::vector<Channel> mChannels[2]; //mChannels[direction]
     std::set<SoapySDR::Stream *> activeStreams;
+    bool _clockExternal{false};
+    double _clockRate{10e6f};
 };


### PR DESCRIPTION
This PR facilitates setting of external clock reference freq. from Soapy.