### PR TITLE
Fix specification of CMAKE_AUTOSET_INSTALL_RPATH CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,7 +199,7 @@ option(CMAKE_SKIP_BUILD_RPATH "skip rpath build" FALSE)
 option(CMAKE_BUILD_WITH_INSTALL_RPATH "build with install rpath" FALSE)
 
 # the RPATH to be used when installing, but only if it's not a system directory
-option(CMAKE_AUTOSET_INSTALL_RPATH TRUE)
+option(CMAKE_AUTOSET_INSTALL_RPATH "Set RPATH when installing to a non-system directory" FALSE)
 if(CMAKE_AUTOSET_INSTALL_RPATH)
 LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}" isSystemDir)
 IF("${isSystemDir}" STREQUAL "-1")


### PR DESCRIPTION
The code before this change did not provide any help text to the option, which made it so CMake defined an option with TRUE as description, and default value of OFF as per the CMake documentation:

  https://cmake.org/cmake/help/latest/command/option.html

This can be verified by checking on the CMakeCache.txt:

```
//TRUE
CMAKE_AUTOSET_INSTALL_RPATH:BOOL=OFF
```

This option was introduced in the commit 416510492d4 with an intent to disable the automatic RPATH logic for Debian packing.

This change merely sanitizes the CMake usage, making it less confusing for a reader: it seemed that the option was set to TRUE while the confusingly it was set to OFF. There is no expected change in behavior with this change.