### PR TITLE
debian/control: update libwxgtk dep for bookworm

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends:
     debhelper (>= 9.0.0),
     cmake (>= 3.1.3),
     libusb-1.0-0-dev,
-    libwxgtk3.0-dev | libwxgtk3.0-gtk3-dev,
+    libwxgtk3.0-dev | libwxgtk3.0-gtk3-dev | libwxgtk3.2-dev,
     libsoapysdr-dev,
     freeglut3-dev,
     libfltk1.3-dev,


### PR DESCRIPTION
Make the package build on debian bookworm (12).