### PR TITLE
Fix hard-to-read log text on dark mode themes

### DIFF
--- a/src/utilities_gui/pnlMiniLog.cpp
+++ b/src/utilities_gui/pnlMiniLog.cpp
@@ -71,6 +71,16 @@ pnlMiniLog::pnlMiniLog(wxWindow* parent, wxWindowID id, const wxPoint& pos, cons
 
 	mDefaultStyle = txtMessageField->GetDefaultStyle();
 	wxUpdateUIEvent::SetUpdateInterval(100);
+
+    // Explicitly set the text color. Without this setting the style back to the
+    // default will always use the black color. Explicitly setting the color to
+    // the color provided via the default attribute makes the text colored
+    // correctly on both dark and light modes.
+    if (!mDefaultStyle.HasTextColour())
+    {
+        const wxVisualAttributes attr = txtMessageField->GetDefaultAttributes();
+        mDefaultStyle.SetTextColour(attr.colFg);
+    }
 }
 
 void pnlMiniLog::HandleMessage(wxCommandEvent &event)


### PR DESCRIPTION
When the Lime Suite GUI is used on a macOS which is default to the dark mode the information logged into the log window was hard to read: it was defaulting to the black foreground.

The behavior now matched when no SetDefaultStyle() used at all: the light theme will use black text, and the dark theme will use the white color.

The limitation this change does not address is the update of the colors in the log window when the theme is changed between dark ans light while the LimeSuiteGUI is running.