### PR TITLE
lms7002m_mcu: fix `gcc-13` build (missing <stdint.h>)

### DIFF
--- a/src/lms7002m_mcu/MCU_File.cpp
+++ b/src/lms7002m_mcu/MCU_File.cpp
@@ -1,6 +1,7 @@
 #include "MCU_File.h"
 #include <algorithm>
 #include <iostream>
+#include <stdint.h>
 
 using namespace std;
 


### PR DESCRIPTION
Without the change build on `gcc-13` fails as:

    /build/source/src/lms7002m_mcu/MCU_File.cpp:340:21: error: 'uint8_t' was not declared in this scope
      340 |                     uint8_t i = 0;
          |                     ^~~~~~~
    /build/source/src/lms7002m_mcu/MCU_File.cpp:4:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
        3 | #include <iostream>
      +++ |+#include <cstdint>