### PR TITLE
Fix warning background "sticky" behavior

### DIFF
--- a/src/utilities_gui/pnlMiniLog.cpp
+++ b/src/utilities_gui/pnlMiniLog.cpp
@@ -76,11 +76,14 @@ pnlMiniLog::pnlMiniLog(wxWindow* parent, wxWindowID id, const wxPoint& pos, cons
     // default will always use the black color. Explicitly setting the color to
     // the color provided via the default attribute makes the text colored
     // correctly on both dark and light modes.
+    //
+    // Do it for both foreground and background, so that the style can be fully
+    // restored after it has been altered for the error or warning.
+    const wxVisualAttributes attr = txtMessageField->GetDefaultAttributes();
     if (!mDefaultStyle.HasTextColour())
-    {
-        const wxVisualAttributes attr = txtMessageField->GetDefaultAttributes();
         mDefaultStyle.SetTextColour(attr.colFg);
-    }
+    if (!mDefaultStyle.HasBackgroundColour())
+        mDefaultStyle.SetBackgroundColour(attr.colBg);
 }
 
 void pnlMiniLog::HandleMessage(wxCommandEvent &event)


### PR DESCRIPTION
After a warning error has been logged in the LimeSuiteGUI all the following messages had an yellow background, which is an unexpected behavior.

Apparently it was caused by the previous fix in the area which made it so the text color is restored to its default value. Somehow it had an effect on the background color behavior: as if there is some implicit behavior when neither of the foreground and background are set in the style when it is set as default to the message field.

It is hard to tell now if this was an oversight in the previous fix, or is it something changed in the wxWidgets library. In any case the logging behavior has been verified once again on both Dark and Light themes on macOS.