### PR TITLE
Update CMakeList for modern macOS versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,10 @@ option(CMAKE_INSTALL_RPATH_USE_LINK_PATH "build with automatic rpath" TRUE)
 
 if(APPLE)
     set(CMAKE_MACOSX_RPATH ON)
+
+    if(CURRENT_OSX_VERSION GREATER_EQUAL 13.0)
+        set(CMAKE_EXE_LINKER_FLAGS "-Wl,-rpath,/usr/local/lib")
+    endif()
 endif()
 
 ########################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,7 +215,7 @@ if(APPLE)
     set(CMAKE_MACOSX_RPATH ON)
 
     if(CURRENT_OSX_VERSION GREATER_EQUAL 13.0)
-        set(CMAKE_EXE_LINKER_FLAGS "-Wl,-rpath,/usr/local/lib")
+        SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}")
     endif()
 endif()
 


### PR DESCRIPTION
Hello!

I recently upgraded to a new MacBook Pro. Since I planned on using my LimeSDR in combination with the new laptop I had to compile LimeSuite from source since homebrew no longer offers prebuilt versions.

Everything compiled fine but running certain executables (for example LimeUtil) resulted in errors like this:

```
dyld[22779]: Library not loaded: @rpath/libLimeSuite.23.11-1.dylib
  Referenced from: <49EAFDEF-E479-36A4-8FEC-3E2A8E368C49> /usr/local/bin/LimeUtil
  Reason: no LC_RPATH's found
zsh: abort      LimeUtil
```

Updating the main CMakeLists file with the content of this pull request fixes the issue and everything runs fine again.
It appears to be an issue with recent macOS versions as I could reproduce it on macOS 13 (Intel CPU) and macOS 14 (M3 Pro CPU). In both cases it is now working fine.

![Bildschirmfoto 2023-12-29 um 19 01 47](https://github.com/myriadrf/LimeSuite/assets/12500014/85289a5c-fde6-4d79-8990-22d25c31479c)

