### PR TITLE
Fix singleRX example to work correctly with LimeSDR Mini V2

### DIFF
--- a/src/examples/singleRX.cpp
+++ b/src/examples/singleRX.cpp
@@ -54,6 +54,9 @@ int main(int argc, char** argv)
     if (LMS_Init(device) != 0)
         error();
 
+    if (LMS_EnableChannel(device, LMS_CH_TX, 0, true)!=0)	// Fix for v2
+        error();
+
     //Enable RX channel
     //Channels are numbered starting at 0
     if (LMS_EnableChannel(device, LMS_CH_RX, 0, true) != 0)


### PR DESCRIPTION
The issue this commit fixes is that running singleRX example does not show any samples streaming, and logs shows: RX data rate: 0 MB/s.

The fix follows the initialization order in basicRX.cpp where the TX channel is enabled alongside with the RX channel right after the LMS_Init(). With this fix running singleRX example shows samples streamed: RX data rate: 32.1454 MB/s.

This is a bit counter-intuitive API from developers perspective (as in, intuitively question is why TX channel is needed for RX-only application). So it does feel like that perhaps the fix needs to be done somewhere deeper in the driver or in gateware to increase clarity of API. However, that'd be a deeper change, if it happens. In any case, until such possible change the proposal is to fix the issue in the same way as it is done in the other example.

The motivation to get the example fixed is because this is something that new LimeSDR users run into as some of their first steps, so having examples properly working solves initial confusion and possible frustration.